### PR TITLE
Added .env file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # dependencies
 /client/node_modules
 /api/node_modules
+/api/.env
 /.pnp
 .pnp.js
 

--- a/api/db/index.js
+++ b/api/db/index.js
@@ -1,4 +1,15 @@
 var firebase = require('firebase');
+require('dotenv').config();
+
+var firebaseConfig = {
+    apiKey: process.env.API_KEY,
+    authDomain: process.env.AUTH_DOMAIN,
+    databaseURL: process.env.DATABASE_URL,
+    projectId: process.env.PROJECT_ID,
+    storageBucket: process.env.STORAGE_BUCKET,
+    messagingSenderId: process.env.MESSAGING_SENDER_ID,
+    appId: process.env.APP_ID
+};
 
 const db = firebase.default.initializeApp(firebaseConfig);
 


### PR DESCRIPTION
This PR hides our API keys away in a .env file.

Look in #coding on Discord to see how to set up Firebase access for development. You won't need to worry about deleting keys anymore before making a PR.