### PR TITLE
Update Leave Trip to remove traveler that left from their assigned Items

### DIFF
--- a/api/routes/trip.js
+++ b/api/routes/trip.js
@@ -10,7 +10,7 @@ const {
   updateTrip,
   deleteTrip,
 } = require("../db/models/trip");
-const {deleteItem, getItemList} = require("../db/models/item");
+const {deleteItem, getItemList, updateItem} = require("../db/models/item");
 const {getExpenseList, deleteExpense} = require("../db/models/expense");
 var router = express.Router();
 
@@ -197,9 +197,27 @@ router.post("/leaveTrip", function (req, res, next) {
       }
       trip.tripLeaders = newTripLeaders;
     }
+    // Handle updating the Item Objects in the abscence of the Traveler
+    if(trip.itemIds) getItemList(trip.itemIds, handleGetItems);
+
+    // Handle updating the Expense in the abscence of the Traveler
     // Update the Trip Object
     updateTrip(trip, handleUpdateTrip);
   };
+  // For each item in the Trip, if the person leaving is assigned to it, blank out the assignee
+  handleGetItems = (items) => {
+    if(items) {
+      let itemsListLength = Object.keys(items).length;
+      for(let l = 0; l < itemsListLength; l++) {
+        if(items[l].assignee === req.body.travelerId) {
+          let newItem = items[l];
+          newItem.assignee = null;
+          updateItem(newItem, handleUpdateItem);
+        }
+      }
+    }
+  };
+  handleUpdateItem = (error) => {};
   handleUpdateTrip = (error) => {
     if (error) res.sendStatus(401);
     else res.sendStatus(200);

--- a/client/src/components/trip/Items.js
+++ b/client/src/components/trip/Items.js
@@ -86,8 +86,15 @@ class Items extends Component {
   }
 
   createItemPane = (item) => {
-    const assignee = this.state.travelers[item.assignee];
-    const name = assignee.firstName + " " + assignee.lastName;
+    let assignee;
+    let name ;
+    if(item.assignee) {
+      assignee = this.state.travelers[item.assignee];
+      name = assignee.firstName + " " + assignee.lastName;
+    }
+    else {
+      name = "";
+    }
     return(
       <Tab.Pane key={item.id} eventKey={`#${item.id}`}>
         <h5>{item.name}</h5>


### PR DESCRIPTION
This PR includes the following features:

- Updates the Leave Trip Functionality to correctly assigned the Items in which the Traveler are assigned to as null rather than keeping it and causing errors.

Testing: Tested by using two accounts. Account A owns the Trip. Account B is a member in the Trip. B creates an item then leaves. Item is then correctly assigned to no one and can be reassigned.