### PR TITLE
Manage Trip Leaders

### DIFF
--- a/api/routes/trip.js
+++ b/api/routes/trip.js
@@ -91,8 +91,13 @@ router.post("/sendInvite", function (req, res, next) {
   getTraveler(req.body.id, handleGetTraveler);
 });
 
-router.put("/addTripLeader", function (req, res, next) {
-  res.send("Not Implemented!");
+router.post("/addTripLeader", function (req, res, next) {
+  handleUpdateTrip = (error) => {
+    if (error) res.sendStatus(401);
+    else res.sendStatus(200);
+  }
+
+  updateTrip(req.body, handleUpdateTrip);
 });
 
 router.delete("/deleteTraveler", function (req, res, next) {

--- a/client/src/components/trip/Trip.js
+++ b/client/src/components/trip/Trip.js
@@ -10,8 +10,7 @@ import Expenses from "./Expenses";
 import ConfirmDelete from "./modals/ConfirmDelete";
 import ConfirmLeave from "./modals/ConfirmLeave";
 import EditTrip from "./modals/EditTrip";
-import AddItem from "./modals/AddItem";
-import AddExpense from "./modals/AddExpense";
+import AddTripLeader from "./modals/AddTripLeader";
 
 import Fade from "react-reveal/Fade";
 import tripIcon from "../../Media/tripIcon.svg";
@@ -26,6 +25,7 @@ class Trip extends Component {
       showLeaveTrip: false,
       showEditTrip: false,
       showAddItem: false,
+      showAddTripLead: false,
       tripData: {},
     };
 
@@ -42,6 +42,8 @@ class Trip extends Component {
     this.openAddItemModal = this.openAddItemModal.bind(this);
     this.closeAddItemModal = this.closeAddItemModal.bind(this);
 
+    this.openAddTripLeaderModal = this.openAddTripLeaderModal.bind(this);
+    this.closeAddTripLeaderModal = this.closeAddTripLeaderModal.bind(this);
   }
 
   // Handle modal visibility
@@ -77,6 +79,14 @@ class Trip extends Component {
     this.setState({ showAddItem: true });
   };
 
+  closeAddTripLeaderModal = () => {
+    this.setState({ showAddTripLead: false })
+  }
+
+  openAddTripLeaderModal = () => {
+    this.setState({ showAddTripLead: true })
+  }
+
   // Retrieve all releveant data
   getTripJSON = (callback) => {
     fetch("http://localhost:9000/trip/getTrip", {
@@ -111,13 +121,23 @@ class Trip extends Component {
   showDeleteTrip = () => {
     if (this.isTripLeader())
       return (
-        <Button
-          variant="danger"
-          className="float-right"
-          onClick={this.openDeleteTripModal}
-        >
-          Delete Trip
-        </Button>
+        <div> 
+          <Button
+            variant="danger"
+            className="float-right ml-1"
+            onClick={this.openDeleteTripModal}
+          >
+            Delete Trip
+          </Button>
+
+          <Button
+            variant="warning"
+            className="float-right ml-1"
+            onClick={this.openAddTripLeaderModal}
+          >
+            Manage Trip Leaders
+          </Button>
+        </div>
       );
   };
 
@@ -184,6 +204,16 @@ class Trip extends Component {
           redirectTrip={this.props.redirectTrip}
           handleClose={this.closeLeaveTripModal}
         ></ConfirmLeave>
+        <AddTripLeader
+          tripId={this.state.tripData.id}
+          tripOwner={this.state.tripData.travelerId}
+          travelerIds={this.state.tripData.travelerIds}
+          tripLeaders={this.state.tripData.tripLeaders}
+          show={this.state.showAddTripLead}
+          refreshTrip={this.refreshTripJSON}
+          handleClose={this.closeAddTripLeaderModal}
+        >
+        </AddTripLeader>
         <EditTrip
           show={this.state.showEditTrip}
           handleClose={this.closeEditTripModal}
@@ -258,9 +288,9 @@ class Trip extends Component {
 
               <Row>
                 <Col>
-                  <Button onClick={this.openEditTripModal}>Edit Trip</Button>
-                  {this.showLeaveTrip()}
-                  {this.showDeleteTrip()}
+                  <Button className="float-left ml-1" onClick={this.openEditTripModal}>Edit Trip</Button>
+                  {this.showDeleteTrip()}{this.showLeaveTrip()}
+                  
                 </Col>
               </Row>
             </Container>

--- a/client/src/components/trip/modals/AddTripLeader.js
+++ b/client/src/components/trip/modals/AddTripLeader.js
@@ -1,0 +1,122 @@
+import React, { Component } from "react";
+import { Form, Button, Modal, ListGroup, Alert } from "react-bootstrap";
+
+class AddTripLeader extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            render: false,
+            visible: false,
+            message: "",
+            status: "",
+        }
+    }
+
+    setTripLeaders = (event) => {
+        event.preventDefault();
+        if (event.target.elements.length <= 2) {
+            this.props.handleClose();
+        }
+
+        const numChecks = event.target.elements.length - 2;
+        var tripLeaders = [this.props.tripOwner];
+        for (var i = 0; i < numChecks; i++) {
+            const currTraveler = event.target.elements[i];
+            if (currTraveler.checked) tripLeaders.push(currTraveler.name);
+        }
+
+        fetch("http://localhost:9000/trip/addTripLeader", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ id: this.props.tripId, tripLeaders }),
+        }).then((res) => {
+            this.props.refreshTrip();
+            this.props.handleClose();
+        });
+    }
+
+    getTravelerJSON = () => {
+        fetch("http://localhost:9000/trip/getTravelers", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ travelerIds: this.props.travelerIds }),
+        }).then((res) => res.json()).then((res) => {
+            this.setState({ travelers: res.travelers, render: true })
+        });
+    }
+
+    createTraveler = (traveler) => {
+        const name = traveler.firstName + " " + traveler.lastName;
+        const tripLeader = this.props.tripLeaders.includes(traveler.id);
+        if (traveler.id === this.props.tripOwner) return;
+        return (
+            <Form.Row id={traveler.id} className="m-0 p-0">
+                <Form.Check
+                    type="checkbox"
+                    size="lg"
+                    key={traveler.id}
+                    name={traveler.id}
+                    label={name}
+                    id={traveler.id}
+                    defaultChecked={tripLeader}
+                />
+            </Form.Row>
+        )
+
+    }
+
+    renderTravelers = () => {
+        if (!this.state.travelers) return;
+        var formChecks = [];
+        for (const traveler of this.state.travelers) {
+            formChecks.push(this.createTraveler(traveler));
+        }
+        return formChecks;
+    }
+
+    showAlert = (message, status) => {
+        this.setState({ message, status, visible: true }, () => {
+        window.setTimeout(() => {
+            this.setState({ visible: false });
+        }, 2000);
+        });
+    };
+
+    componentDidMount() {
+        this.getTravelerJSON();
+    }
+
+    render() {
+        if (!this.state.render) return (<div></div>)
+        return (
+            <Modal
+                show={this.props.show}
+                dialogClassName="modal-60w"
+                aria-labelledby="contained-modal-title-vcenter"
+                onHide={this.props.handleClose}
+                animation={false}
+                centered
+            >
+            <Form onSubmit={this.setTripLeaders} className="p-3">
+              <Modal.Body>
+                <h4>Choose Trip Leaders</h4>
+                {this.renderTravelers()}
+              </Modal.Body>
+              <Modal.Footer>
+                <Button onClick={this.props.handleClose}>Close</Button>
+                <Button variant="success" type="submit">
+                  Save
+                </Button>
+              </Modal.Footer>
+            </Form>
+          </Modal>
+        )
+    }
+}
+
+export default AddTripLeader;
+


### PR DESCRIPTION
Allows Trip Leaders and the Trip Owner to manage who has Trip Leader permissions. The Trip Owner can never have their Trip Leader privileges taken away from them, not even by themselves.

Tested by screwing around adding and removing myself as a leader.