### PR TITLE
Leave Trip now correctly deassigns leaving traveler from Expenses

### DIFF
--- a/api/routes/trip.js
+++ b/api/routes/trip.js
@@ -11,7 +11,7 @@ const {
   deleteTrip,
 } = require("../db/models/trip");
 const {deleteItem, getItemList, updateItem} = require("../db/models/item");
-const {getExpenseList, deleteExpense} = require("../db/models/expense");
+const {getExpenseList, deleteExpense, updateExpense} = require("../db/models/expense");
 var router = express.Router();
 
 router.get("/", function (req, res, next) {
@@ -199,11 +199,26 @@ router.post("/leaveTrip", function (req, res, next) {
     }
     // Handle updating the Item Objects in the abscence of the Traveler
     if(trip.itemIds) getItemList(trip.itemIds, handleGetItems);
-
     // Handle updating the Expense in the abscence of the Traveler
+    if(trip.expenseIds) getExpenseList(trip.expenseIds, handleGetExpenses);
     // Update the Trip Object
     updateTrip(trip, handleUpdateTrip);
   };
+  handleGetExpenses = (expenses) => {
+    if(expenses) {
+      let expensesListLength = Object.keys(expenses).length;
+      for(let n = 0; n < expensesListLength; n++) {
+        let newExpenseAssignees = [];
+        let expenseAssigneesLength = Object.keys(expenses[n].travelerIds).length;
+        for(let t = 0; t < expenseAssigneesLength; t++) {
+          if(expenses[n].travelerIds[t] !== req.body.travelerId) newExpenseAssignees.push(expenses[n].travelerIds[t]);
+        }
+        expenses[n].travelerIds = newExpenseAssignees;
+        updateExpense(expenses[n], handleUpdateExpense);
+      }
+    }
+  }
+  handleUpdateExpense = (error) => {};
   // For each item in the Trip, if the person leaving is assigned to it, blank out the assignee
   handleGetItems = (items) => {
     if(items) {

--- a/client/src/components/trip/Expenses.js
+++ b/client/src/components/trip/Expenses.js
@@ -50,8 +50,7 @@ class Expenses extends Component {
     })
       .then((res) => res.json())
       .then((res) => {
-        this.getTravelersJSON(res.expenses)
-        // this.setState({ expenses: res.expenses, render: true });
+        this.getTravelersJSON(res.expenses);
       });
   };
 
@@ -95,12 +94,13 @@ class Expenses extends Component {
 
   createExpenseTabPane = (expense) => {
     let arr = [];
+    let travelerList = <div></div>;
     if(expense.travelerIds) {
       for (let i = 0; i < Object.keys(expense.travelerIds).length; i++) {
         arr.push(this.state.travelers[expense.travelerIds[i]]);
       }
+      travelerList = arr.map((traveler) => <li>{traveler} </li>);
     }
-    const travelerList = arr.map((traveler) => <li>{traveler} </li>);
     return (
       <Tab.Pane key={expense.id} eventKey={`#${expense.id}`}>
         <h5>{expense.name}</h5>


### PR DESCRIPTION
This PR completes the Leave Trip functionality.
Features:

- Updates the Leave Trip functionality to correctly unassign the leaving Traveler from Expenses in the Trip.

Testing: Ran on local machine. Tested using two accounts in which the one of the accounts creates a trip then leaves. Checked on other account to see that Expense was still in the Trip and that it was assigned from the leaving Traveler.