### PR TITLE
Fixed email in use create account

### DIFF
--- a/src/components/account/CreateAccount.js
+++ b/src/components/account/CreateAccount.js
@@ -33,7 +33,7 @@ class CreateAccount extends Component {
         if (res.code === "auth/email-already-in-use") {
           alert("This email is already in use.");
         }
-        if (res.code === "auth/weak-password") {
+        else if (res.code === "auth/weak-password") {
           alert("Your password is too weak.");
         }
         else {


### PR DESCRIPTION
This PR resolves the following issue:

- Users who try to create an account with an email that is in use will be logged into the account

Testing: Ran on local machine. Tested creating an account that was already in use.