### PR TITLE
Fixed Account Creation bug and changed Friend invitation message to be more succinct

### DIFF
--- a/src/components/Friends.js
+++ b/src/components/Friends.js
@@ -34,7 +34,7 @@ class Friends extends Component {
       this.getFriends();
       
       if (res.status === 200)
-        this.showAlert("Successfully added Friend!", "success");
+        this.showAlert("Successfully sent Friend invitation!", "success");
       else if (res.status === 202)
         this.showAlert("You are already Friends with this Traveler.", "warning");
       else if (res.status === 203)

--- a/src/components/account/Account.js
+++ b/src/components/account/Account.js
@@ -35,7 +35,7 @@ class Account extends Component {
 
   // Parse Miliseconds to Date string
   getDateCreatedOn() {
-    return Date(parseInt(this.props.traveler.createdOn,10)).toString('MM/dd/yy HH:mm:ss');
+    return new Date(parseInt(this.props.traveler.createdOn,10)).toString('MM/dd/yy HH:mm:ss');
   }
   render() {
     return (


### PR DESCRIPTION
This PR changes the following:
- "Title"

Testing: Ran on local machine. Tested by going to account page and seeing that the account creation date is accurate.